### PR TITLE
Fix minor typo

### DIFF
--- a/vt-subdomains.py
+++ b/vt-subdomains.py
@@ -16,7 +16,7 @@ def main(domain, apikey):
         print("No domains found for %s" % domain)
         exit(0)
     except(requests.ConnectionError):
-        print("Could not connect to www.virtustotal.com", file=sys.stderr)
+        print("Could not connect to www.virustotal.com", file=sys.stderr)
         exit(1)
 
     for domain in domains:


### PR DESCRIPTION
There is a very minor typo in the error message:
```python3
print("Could not connect to www.virtustotal.com", file=sys.stderr)
```
`www.virtustotal.com` appears to currently be parked.
Thank you